### PR TITLE
Handle the case of overflow or invalid parameters while tuning the st…

### DIFF
--- a/R/Rcgminb.R
+++ b/R/Rcgminb.R
@@ -500,6 +500,11 @@ Rcgminb <- function(par, fn, gr, lower, upper, bdmsk = NULL, control = list(), .
                     if (changed) {
                       f <- fn(bvec, ...)
                       ifn <- ifn + 1
+                        
+                      if (is.na(f) || (!is.finite(f))) {
+                        warning("Rcgmin - undefined function")
+                        f <- .Machine$double.xmax
+                      }
                     }
                     if (trace > 2) 
                       cat("fmin, f1, f: ", fmin, f1, f, "\n")

--- a/R/Rcgminu.R
+++ b/R/Rcgminu.R
@@ -283,6 +283,9 @@ Rcgminu <- function(par, fn, gr, control = list(), ...) {
                     if (changed) {
                       f <- fn(bvec, ...)
                       ifn <- ifn + 1
+                        
+                      if (is.nan(f) || is.na(f))
+                          f <- Inf
                     }
                     if (trace > 2) 
                       cat("fmin, f1, f: ", fmin, f1, f, "\n")

--- a/R/Rcgminu.R
+++ b/R/Rcgminu.R
@@ -284,8 +284,10 @@ Rcgminu <- function(par, fn, gr, control = list(), ...) {
                       f <- fn(bvec, ...)
                       ifn <- ifn + 1
                         
-                      if (is.nan(f) || is.na(f))
-                          f <- Inf
+                      if (is.na(f) || (!is.finite(f))) {
+                        warning("Rcgmin - undefined function")
+                        f <- .Machine$double.xmax
+                      }
                     }
                     if (trace > 2) 
                       cat("fmin, f1, f: ", fmin, f1, f, "\n")


### PR DESCRIPTION
…ep size.

I encountered an issue where, while tuning the step size, my model code was returning NaN. This caused Rcgmin's optimization to crash because it was assumed on line 289 that the value of f would be numeric (in order to compute the value of the condition in `if (f < min(fmin, f1))`). Replacing non-numeric values of f by Inf allows the step-size optimization to continue in this case.